### PR TITLE
test(auth): add testcase when the client doesn't provide redirect url

### DIFF
--- a/test/e2e/auth_discord_test.go
+++ b/test/e2e/auth_discord_test.go
@@ -119,6 +119,17 @@ func (suite *E2ETestSuite) TestDiscordCallback() {
 			queryParams:    map[string]string{},
 			expectedStatus: http.StatusUnauthorized,
 		},
+		{
+			name:         "redirect cookie is missing",
+			prepareMocks: func() {},
+			cookies: map[string]string{
+				"state": "state",
+			},
+			queryParams: map[string]string{
+				"state": "state",
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a test case to verify that the authentication flow correctly returns an unauthorized response when a required cookie is missing.
	- Added a test case to check the handling of errors when retrieving user information during the authentication process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->